### PR TITLE
Add ability to configure timeout in backup-daemon

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -31,6 +31,7 @@ type BackupDaemon struct {
 	BackupSchedule         string                   `json:"backupSchedule,omitempty"`
 	GranularEviction       string                   `json:"granularEviction,omitempty"`
 	JobFlag                string                   `json:"jobFlag,omitempty"`
+	ConnectTimeout         string                   `json:"connectTimeout,omitempty"`
 	GranularBackupSchedule string                   `json:"granularBackupSchedule,omitempty"`
 	DatabasesToSchedule    string                   `json:"databasesToSchedule,omitempty"`
 	WalArchiving           bool                     `json:"walArchiving,omitempty"`

--- a/pkg/reconciler/backup.go
+++ b/pkg/reconciler/backup.go
@@ -135,6 +135,10 @@ func NewBackupDaemonDeployment(backupDaemon *types.BackupDaemon, pgClusterName s
 									Value: backupDaemon.JobFlag,
 								},
 								{
+									Name:  "CONNECT_TIMEOUT",
+									Value: backupDaemon.ConnectTimeout,
+								},
+								{
 									Name:  "ALLOW_PREFIX",
 									Value: strconv.FormatBool(backupDaemon.AllowPrefix),
 								},


### PR DESCRIPTION
Added new env variable connect_timeout to provide ability to configure timeout for backup-daemon to connect with pg-patroni.