### PR TITLE
New env variable for backup-daemon for configuring extension list to exclude

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -36,6 +36,7 @@ type BackupDaemon struct {
 	DatabasesToSchedule    string                   `json:"databasesToSchedule,omitempty"`
 	WalArchiving           bool                     `json:"walArchiving,omitempty"`
 	AllowPrefix            bool                     `json:"allowPrefix,omitempty"`
+	ExcludedExtensions     string                   `json:"excludedExtensions,omitempty"`
 	UseEvictionPolicyFirst string                   `json:"useEvictionPolicyFirst,omitempty"`
 	EvictionBinaryPolicy   string                   `json:"evictionBinaryPolicy,omitempty"`
 	ArchiveEvictionPolicy  string                   `json:"archiveEvictionPolicy,omitempty"`

--- a/pkg/reconciler/backup.go
+++ b/pkg/reconciler/backup.go
@@ -142,6 +142,10 @@ func NewBackupDaemonDeployment(backupDaemon *types.BackupDaemon, pgClusterName s
 									Name:  "ALLOW_PREFIX",
 									Value: strconv.FormatBool(backupDaemon.AllowPrefix),
 								},
+                                {
+                            	    Name:  "EXCLUDED_EXTENSIONS",
+                            	    Value: backupDaemon.ExcludedExtensions,
+                                },
 								{
 									Name:  "GRANULAR_BACKUP_SCHEDULE",
 									Value: backupDaemon.GranularBackupSchedule,

--- a/pkg/reconciler/backup.go
+++ b/pkg/reconciler/backup.go
@@ -142,10 +142,10 @@ func NewBackupDaemonDeployment(backupDaemon *types.BackupDaemon, pgClusterName s
 									Name:  "ALLOW_PREFIX",
 									Value: strconv.FormatBool(backupDaemon.AllowPrefix),
 								},
-                                {
-                            	    Name:  "EXCLUDED_EXTENSIONS",
-                            	    Value: backupDaemon.ExcludedExtensions,
-                                },
+								{
+									Name:  "EXCLUDED_EXTENSIONS",
+									Value: backupDaemon.ExcludedExtensions,
+								},
 								{
 									Name:  "GRANULAR_BACKUP_SCHEDULE",
 									Value: backupDaemon.GranularBackupSchedule,


### PR DESCRIPTION
Added new env variable to backup daemon which will allow users to specify list of extension which will be excluded from backup-daemon (pg_dump). By default, pg_hint_plan will be excluded as it caused issue when performing backup for azure pg.